### PR TITLE
[Patch] ES6 & CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 - `checkEqual(a, b, strictMode)`
   - `a` and `b` are two objects for checking, they can be array/string/number/JSON/function, etc.
-  - `strictMode` defaults to `true`, if true we check by `===` internally, otherwise, we check by `==`.
+  - `strictMode` defaults to `true`, if true we check by `===` internally, otherwise, we check by `==`. Furthermore, if false we will ignore item order when checking arrays.
 
 ## Example
 
@@ -77,7 +77,9 @@ checkEqual(true, false) //false
 
 checkEqual([1, 2, 3], [1, 2, 3]) //true
 
-checkEqual([1, 2, 3], [3, 1, 2]) //true
+checkEqual([1, 2, 3], [3, 1, 2], false) //true
+
+checkEqual([1, 2, 3], [3, 1, 2], true) //false
 
 checkEqual([1, 2, 3], [1, 2]) //false (different length)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.5",
+  "version": "1.0.1-alpha.6",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
@@ -9,9 +9,11 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts"
     }
   },
+  "types": "dist/**/*.d.ts",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -38,18 +40,15 @@
     "node": ">=16"
   },
   "scripts": {
-    "compile:esm": "./node_modules/.bin/tsc",
-    "compile:cjs": "./node_modules/.bin/tsc -m node16 --moduleResolution node16 --outDir dist/cjs",
+    "compile:esm": "./node_modules/.bin/tsc -p tsconfig-esm.json",
+    "compile:cjs": "./node_modules/.bin/tsc -p tsconfig-cjs.json",
     "build": "rm -rf ./dist & yarn compile:esm & yarn compile:cjs"
   },
   "devDependencies": {
     "typescript": "^5.2.2"
   },
   "files": [
-    "dist/*.js",
-    "dist/*.d.ts",
-    "dist/**/*.js",
-    "dist/**/*.d.ts",
+    "dist/",
     ".gitignore",
     "package.json",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.4",
+  "version": "1.0.1-alpha.5",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1-alpha.2",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
   "type": "module",
-  "exports": "./dist/index.js",
+  "main": "./dist/esm/index.js",
+  "module": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -32,7 +37,9 @@
     "node": ">=16"
   },
   "scripts": {
-    "build": "rm -rf ./dist & ./node_modules/.bin/tsc"
+    "compile:esm": "./node_modules/.bin/tsc",
+    "compile:cjs": "./node_modules/.bin/tsc -m commonjs --outDir dist/cjs",
+    "build": "rm -rf ./dist & yarn compile:esm & yarn compile:cjs"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs",
       "types": "./dist/esm/index.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.2",
+  "version": "1.0.1-alpha.3",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
-  "type": "module",
   "main": "./dist/esm/index.js",
   "module": "./dist/cjs/index.js",
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
   },
   "publishConfig": {
     "access": "public",
@@ -38,7 +39,7 @@
   },
   "scripts": {
     "compile:esm": "./node_modules/.bin/tsc",
-    "compile:cjs": "./node_modules/.bin/tsc -m commonjs --outDir dist/cjs",
+    "compile:cjs": "./node_modules/.bin/tsc -m node16 --moduleResolution node16 --outDir dist/cjs",
     "build": "rm -rf ./dist & yarn compile:esm & yarn compile:cjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
@@ -41,7 +41,7 @@
   "scripts": {
     "compile:esm": "./node_modules/.bin/tsc -p tsconfig-esm.json",
     "compile:cjs": "./node_modules/.bin/tsc -p tsconfig-cjs.json",
-    "build": "rm -rf ./dist & yarn compile:esm & yarn compile:cjs"
+    "build": "rm -rf ./dist & yarn compile:esm & yarn compile:cjs "
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.3",
+  "version": "1.0.1-alpha.4",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
-  "main": "./dist/esm/index.js",
-  "module": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-beta.2",
+  "version": "1.0.1-beta.3",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.0",
+  "version": "1.0.1-alpha.1",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
   "type": "module",
-  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -28,6 +28,9 @@
     "Check objects equal",
     "compare"
   ],
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "build": "rm -rf ./dist & ./node_modules/.bin/tsc"
   },

--- a/package.json
+++ b/package.json
@@ -1,18 +1,11 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-beta.1",
+  "version": "1.0.1-beta.2",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/cjs/index.d.ts"
-    }
-  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/package.json
+++ b/package.json
@@ -1,19 +1,17 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.8",
+  "version": "1.0.1-alpha.9",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.cjs",
-      "types": "./dist/esm/index.d.ts"
+      "require": "./dist/cjs/index.js"
     }
   },
-  "types": "dist/**/*.d.ts",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.7",
+  "version": "1.0.1-alpha.8",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rinxun/check-equal",
-  "version": "1.0.1-alpha.9",
+  "version": "1.0.1-beta.1",
   "description": "A TypeScript library for checking whether two objects are equal (includes type), objects can be array/string/number/JSON/function, etc.",
   "license": "MIT",
   "private": false,
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/cjs/index.d.ts"
     }
   },
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { isNil } from "./utils.js";
+import { isNil } from "./utils";
 
 function sortArray(arr: Array<any>) {
   arr.sort((a, b) => {
@@ -50,9 +50,11 @@ function checkEqualForArray(
   if (arrA.length !== arrB.length) {
     return false;
   } else {
-    //sort array first
-    sortArray(arrA);
-    sortArray(arrB);
+    if (!strictMode) {
+      //sort array first
+      sortArray(arrA);
+      sortArray(arrB);
+    }
     let _equal = true;
     for (let i = 0, l = arrA.length; i < l; i += 1) {
       if (!checkEqual(arrA[i], arrB[i], strictMode)) {

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "CommonJS",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2022",
+    "outDir": "./dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "moduleResolution": "Node",
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["./**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "module": "ES2022",
-    "lib": ["ESNext"],
+    "lib": ["ES2022"],
     "pretty": true,
     "sourceMap": false,
     "declaration": true,
-    "moduleResolution": "node",
     "esModuleInterop": true,
-    "outDir": "./dist",
     "skipLibCheck": true,
     "typeRoots": ["node_modules/@types"]
   },


### PR DESCRIPTION
## Notes

- Fix: Package can't be imported/used in CommonJS
- Enhance: Use `exports` in `package.json` to support different entrances for ES6 and CommonJS
- Enhance: If `strictMode` is true, don't sort arrays internally